### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides access to Satstream Bitcoin data API.
 
+<a href="https://glama.ai/mcp/servers/@satstream/ss-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@satstream/ss-mcp/badge" alt="Satstream Server MCP server" />
+</a>
+
 ## Setup
 
 To install dependencies:


### PR DESCRIPTION
This PR adds a badge for the [Satstream MCP Server](https://glama.ai/mcp/servers/@satstream/ss-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@satstream/ss-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@satstream/ss-mcp/badge" alt="Satstream Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.